### PR TITLE
fix: Ensure UploadHandlerRaw and DownloadHanderBuffer are disposed

### DIFF
--- a/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
+++ b/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
@@ -15,7 +15,7 @@ namespace GrpcWebSocketBridge.Client.Unity
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var unityWebRequest = new UnityWebRequest(request.RequestUri, request.Method.Method);
+            using var unityWebRequest = new UnityWebRequest(request.RequestUri, request.Method.Method);
             foreach (var header in request.Headers)
             {
                 try
@@ -41,6 +41,9 @@ namespace GrpcWebSocketBridge.Client.Unity
 
             unityWebRequest.uploadHandler = new UploadHandlerRaw(await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false));
             unityWebRequest.downloadHandler = new DownloadHandlerBuffer();
+
+            unityWebRequest.disposeUploadHandlerOnDispose = true;
+            unityWebRequest.disposeDownloadHandlerOnDispose = true;
 
             await unityWebRequest.SendWebRequest();
 


### PR DESCRIPTION
I ran into "A Native Collection has not been disposed" resulting from the UnityWebRequest upload/download handlers.

Fixed by using the UnityWebRequest's disposeUploadHandlerOnDispose & disposeDownloadHandlerOnDispose  options to ensure the handlers are disposed of along with the UnityWebRequest.