### PR TITLE
Handle empty response data in UnityWebRequestHttpHandler

### DIFF
--- a/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
+++ b/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
@@ -48,7 +48,7 @@ namespace GrpcWebSocketBridge.Client.Unity
             {
                 RequestMessage = request,
                 Version = HttpVersion.Version11,
-                Content = new ByteArrayContent(unityWebRequest.downloadHandler.data),
+                Content = new ByteArrayContent(unityWebRequest.downloadHandler.data ?? Array.Empty<byte>()),
             };
 
             foreach (var responseHeader in unityWebRequest.GetResponseHeaders())

--- a/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
+++ b/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
@@ -51,7 +51,7 @@ namespace GrpcWebSocketBridge.Client.Unity
             {
                 RequestMessage = request,
                 Version = HttpVersion.Version11,
-                Content = new ByteArrayContent(unityWebRequest.downloadHandler.data),
+                Content = new ByteArrayContent(unityWebRequest.downloadHandler.data ?? Array.Empty<byte>()),
             };
 
             foreach (var responseHeader in unityWebRequest.GetResponseHeaders())


### PR DESCRIPTION
Throws an exception otherwise as ByteArrayContent does not expect a null value in the ctor.