### PR TITLE
Handle sending trailer for completion when web socket closed

### DIFF
--- a/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs
+++ b/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs
@@ -181,9 +181,19 @@ namespace GrpcWebSocketBridge.Client
             }
             finally
             {
-                // Send a empty trailer for completion.
-                await clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[] {0b10000000, 0x00, 0x00, 0x00, 0x00}), WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
-                await ctx.CompleteRequestAsync().ConfigureAwait(false);
+                try
+                {
+                    // Send a empty trailer for completion.
+                    await clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[] { 0b10000000, 0x00, 0x00, 0x00, 0x00 }), WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
+                }
+                catch (WebSocketException e) when (e.WebSocketErrorCode == WebSocketError.InvalidState)
+                {
+                    // ignore errors when trying to send to already closed web socket
+                }
+                finally
+                {
+                    await ctx.CompleteRequestAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs
+++ b/src/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs
@@ -181,9 +181,19 @@ namespace GrpcWebSocketBridge.Client
             }
             finally
             {
-                // Send a empty trailer for completion.
-                await clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[] {0b10000000, 0x00, 0x00, 0x00, 0x00}), WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
-                await ctx.CompleteRequestAsync().ConfigureAwait(false);
+                try
+                {
+                    // Send a empty trailer for completion.
+                    await clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[] { 0b10000000, 0x00, 0x00, 0x00, 0x00 }), WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
+                }
+                catch (WebSocketException e) when (e.WebSocketErrorCode == WebSocketError.InvalidState)
+                {
+                    // ignore errors when trying to send to already closed web socket
+                }
+                finally
+                {
+                    await ctx.CompleteRequestAsync().ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
GrpcWebSocketBridgeHandler throws an exception when trying to send an empty trailer for completion.

Checking state of the underlying web socket instance before sending an empty trailer does not help, so using a try / catch block instead.

Only `WebSocketError.InvalidState` is handled so should not affect any other functionality.

The error looks like following

```
WebSocketException: The WebSocket is in an invalid state ('Aborted') for this operation. Valid states are: 'Open, CloseReceived'
System.Net.WebSockets.WebSocketValidate.ThrowIfInvalidState (System.Net.WebSockets.WebSocketState currentState, System.Boolean isDisposed, System.Net.WebSockets.WebSocketState[] validStates) (at <6bb3336e864c4ab48c43a2538573e586>:0)
System.Net.WebSockets.ManagedWebSocket.SendPrivateAsync (System.ReadOnlyMemory`1[T] buffer, System.Net.WebSockets.WebSocketMessageType messageType, System.Boolean endOfMessage, System.Threading.CancellationToken cancellationToken) (at <6bb3336e864c4ab48c43a2538573e586>:0)
--- End of stack trace from previous location where exception was thrown ---
GrpcWebSocketBridge.Client.WebSockets.SystemNetWebSocketsClientWebSocket.SendAsync (System.ArraySegment`1[T] buffer, System.Net.WebSockets.WebSocketMessageType messageType, System.Boolean endOfMessage, System.Threading.CancellationToken cancellationToken) (at ./Library/PackageCache/com.cysharp.grpcwebsocketbridge@43c5556d52/GrpcWebSocketBridge.Client/WebSockets/SystemNetWebSocketsClientWebSocket.cs:40)
Cysharp.Threading.Tasks.UniTask+ExceptionResultSource.GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@50a67d8f41/Runtime/UniTask.Factory.cs:205)
Cysharp.Threading.Tasks.UniTask+Awaiter.GetResult () (at ./Library/PackageCache/com.cysharp.unitask@50a67d8f41/Runtime/UniTask.cs:312)
GrpcWebSocketBridge.Client.GrpcWebSocketBridgeHandler.ProcessRequestAsync (GrpcWebSocketBridge.Client.WebSockets.IClientWebSocket clientWebSocket, System.Net.Http.HttpRequestMessage request, GrpcWebSocketBridge.Client.Internal.ConnectionContext ctx, System.Threading.CancellationToken cancellationToken) (at ./Library/PackageCache/com.cysharp.grpcwebsocketbridge@43c5556d52/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs:187)
GrpcWebSocketBridge.Client.GrpcWebSocketBridgeHandler.ProcessRequestAsync (GrpcWebSocketBridge.Client.WebSockets.IClientWebSocket clientWebSocket, System.Net.Http.HttpRequestMessage request, GrpcWebSocketBridge.Client.Internal.ConnectionContext ctx, System.Threading.CancellationToken cancellationToken) (at ./Library/PackageCache/com.cysharp.grpcwebsocketbridge@43c5556d52/GrpcWebSocketBridge.Client/GrpcWebSocketBridgeHandler.cs:196)
UnityEngine.Debug:LogException(Exception)
Cysharp.Threading.Tasks.UniTaskScheduler:PublishUnobservedTaskException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@50a67d8f41/Runtime/UniTaskScheduler.cs:90)
Cysharp.Threading.Tasks.ExceptionHolder:Finalize() (at ./Library/PackageCache/com.cysharp.unitask@50a67d8f41/Runtime/UniTaskCompletionSource.cs:66)

```