### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,17 +12,13 @@ on:
         default: false
         type: boolean
 
-env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  DRY_RUN: ${{ github.event.inputs.dry-run }}
-
 jobs:
   update-packagejson:
     uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
     with:
       file-path: ./src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/package.json
-      tag: ${{ github.event.inputs.tag }}
-      dry-run: ${{ fromJson(github.event.inputs.dry-run) }}
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
 
   build:
     name: "Build & pack GrpcWebSocketBridge"
@@ -36,12 +32,11 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
-      - run: echo "PACKAGE_VERSION=${GIT_TAG}" | tee -a $GITHUB_ENV
       # Build & Pack
-      - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${PACKAGE_VERSION}
-      - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${PACKAGE_VERSION}
-      - run: dotnet pack -c Release --include-symbols --include-source --no-build -p:VersionPrefix=${PACKAGE_VERSION} -o ./publish/
-      - uses: actions/upload-artifact@v1
+      - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
+      - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
+      - run: dotnet pack -c Release --include-symbols --include-source --no-build -p:VersionPrefix=${{ inputs.tag }} -o ./publish/
+      - uses: actions/upload-artifact@v3
         with:
           name: nuget
           path: ./publish/
@@ -55,12 +50,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       # Build & Publish
-      - run: dotnet publish -f netstandard2.0 -c Release -o ./publish/Grpc.Net.Client/netstandard2.0/ ./src/External/Grpc.Net.Client
-      - run: dotnet publish -f netstandard2.1 -c Release -o ./publish/Grpc.Net.Client/netstandard2.1/ ./src/External/Grpc.Net.Client
-      - uses: actions/upload-artifact@v1
+      - run: dotnet publish -f netstandard2.0 -c Release -o ./publish/Grpc.Net.Client-ModifiedForWebGL/Grpc.Net.Client/netstandard2.0/ ./src/External/Grpc.Net.Client
+      - run: dotnet publish -f netstandard2.1 -c Release -o ./publish/Grpc.Net.Client-ModifiedForWebGL/Grpc.Net.Client/netstandard2.1/ ./src/External/Grpc.Net.Client
+      - run: zip -r ./Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip ./Grpc.Net.Client-ModifiedForWebGL/
+        working-directory: ./publish/
+      - uses: actions/upload-artifact@v3
         with:
-          name: Grpc.Net.Client-ModifiedForWebGL
-          path: ./publish/
+          name: Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip
+          path: ./publish/Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip
 
   build-unity:
     name: "Build Unity package"
@@ -82,7 +79,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
+          UNITY_PACKAGE_VERSION: ${{ inputs.tag }}
         with:
           projectPath: src/GrpcWebSocketBridge.Client.Unity
           unityVersion: ${{ matrix.unity }}
@@ -94,77 +91,25 @@ jobs:
           directory: src/GrpcWebSocketBridge.Client.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
-          name: GrpcWebSocketBridge.${{ env.GIT_TAG }}.unitypackage
-          path: ./src/GrpcWebSocketBridge.Client.Unity/GrpcWebSocketBridge.${{ env.GIT_TAG }}.unitypackage
+          name: GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage
+          path: ./src/GrpcWebSocketBridge.Client.Unity/GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage
 
-  push:
-    if: ${{ github.event.inputs.dry-run == 'false' }}
-    name: "Push NuGet packages"
-    needs: [build, build-grpc-dotnet, build-unity]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts
-      - name: Publish to NuGet
-        run: dotnet nuget push "./artifacts/nuget/*.nupkg" --skip-duplicate -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-
+  # release
   create-release:
-    if: ${{ github.event.inputs.dry-run == 'false' }}
-    name: "Create GitHub Release"
     needs: [update-packagejson, build, build-grpc-dotnet, build-unity]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        id: create_release
-        with:
-          tag_name: ${{ env.GIT_TAG }}
-          commitish: ${{ needs.update-packagejson.outputs.sha }}
-          draft: true
-          prerelease: false
-          generate_release_notes: true
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts
-
-      - name: Create archive (Grpc.Net.Client-ModifiedForWebGL.zip)
-        run: zip -r Grpc.Net.Client-ModifiedForWebGL.zip ./Grpc.Net.Client-ModifiedForWebGL/
-        working-directory: artifacts
-
-      - name: Display downloaded artifact files
-        run: ls -lR
-        working-directory: artifacts
-
-      # Upload to Releases
-      - name: Upload to Release (Grpc.Net.Client-ModifiedForWebGL.zip)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/Grpc.Net.Client-ModifiedForWebGL.zip
-          asset_name: Grpc.Net.Client-ModifiedForWebGL.${{ env.GIT_TAG }}.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload to Release (GrpcWebSocketBridge.unitypackage)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/GrpcWebSocketBridge.${{ env.GIT_TAG }}.unitypackage/GrpcWebSocketBridge.${{ env.GIT_TAG }}.unitypackage
-          asset_name: GrpcWebSocketBridge.${{ env.GIT_TAG }}.unitypackage
-          asset_content_type: application/octet-stream
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      dry-run: ${{ inputs.dry-run }}
+      tag: ${{ inputs.tag }}
+      nuget-push: true
+      release-upload: true
+      release-asset-path: |
+        ./Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip/Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip
+        ./GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage/GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage
+    secrets: inherit
 
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -109,6 +109,7 @@ jobs:
       release-asset-path: |
         ./Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip/Grpc.Net.Client-ModifiedForWebGL.${{ inputs.tag }}.zip
         ./GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage/GrpcWebSocketBridge.${{ inputs.tag }}.unitypackage
+      release-format: '{0}'
     secrets: inherit
 
   cleanup:


### PR DESCRIPTION
## tl;dr;

Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`.

This brings central managed release flow control.

see: https://github.com/Cysharp/GrpcWebSocketBridge/actions/runs/7813917750