### PR TITLE
Fixing Content-Type bug for HTTP/1.1 POST Unary requests in Unity

### DIFF
--- a/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
+++ b/src/GrpcWebSocketBridge.Client.Unity/Assets/Plugins/GrpcWebSocketBridge/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
@@ -17,7 +17,7 @@ namespace GrpcWebSocketBridge.Client.Unity
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
         {
             using var uploadHandler = new UploadHandlerRaw(await requestMessage.Content.ReadAsByteArrayAsync());
-            uploadHandler.contentType = requestMessage.Headers.Accept.ToString();
+            uploadHandler.contentType = requestMessage.Content.Headers.ContentType.ToString();
 
             using var downloadHandler = new DownloadHandlerBuffer();
             using var webRequest = new UnityWebRequest(requestMessage.RequestUri, requestMessage.Method.ToString(), downloadHandler, uploadHandler);

--- a/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
+++ b/src/GrpcWebSocketBridge.Client/Unity/UnityWebRequestHttpHandler.cs
@@ -17,7 +17,7 @@ namespace GrpcWebSocketBridge.Client.Unity
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
         {
             using var uploadHandler = new UploadHandlerRaw(await requestMessage.Content.ReadAsByteArrayAsync());
-            uploadHandler.contentType = requestMessage.Headers.Accept.ToString();
+            uploadHandler.contentType = requestMessage.Content.Headers.ContentType.ToString();
 
             using var downloadHandler = new DownloadHandlerBuffer();
             using var webRequest = new UnityWebRequest(requestMessage.RequestUri, requestMessage.Method.ToString(), downloadHandler, uploadHandler);


### PR DESCRIPTION
As described in https://github.com/Cysharp/GrpcWebSocketBridge/issues/39 , there is a bug when trying to create Unary requests from Unity.
At the server side, the request content type will appear as `application/octet-stream` instead of the expected `application/grpc-web` which will not allow the GrpcWebSocketBridge middleware to execute properly because of this condition:
https://github.com/Cysharp/GrpcWebSocketBridge/blob/8e37d22c8110816b2d96bf6c7aa7eae306705a6d/src/GrpcWebSocketBridge.AspNetCore/GrpcWebBridgeMiddleware.cs#L25

The reason for this problem seems to be the implementation of the HTTP handler set for versions higher than Unity 2018.1, that uses `UnityWebRequestHttpHandler`.

In the implementation of `UnityWebRequestHttpHandler`, the Content Type seems to be set by the request accept header, but at no time in the creation of the request this header is set, instead the correct Content Type is set on the request content header "Content-Type".

I changed the implementation of `UnityWebRequestHttpHandler` to use this header.