### PR TITLE
ci: use OIDC for NuGet package push authentication

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -29,8 +29,8 @@ jobs:
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Debug
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Release
       # Pack
-      - run: dotnet pack -c Release --no-build  -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build  -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
 
   build-unity:
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -29,8 +29,8 @@ jobs:
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Debug
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Release
       # Pack
-      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
 
   build-unity:
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -29,8 +29,8 @@ jobs:
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Debug
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Release
       # Pack
-      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
 
   build-unity:
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -29,8 +29,8 @@ jobs:
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Debug
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Release
       # Pack
-      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionSuffix=${PACKAGE_VERSION} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
 
   build-unity:
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -29,8 +29,8 @@ jobs:
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Debug
       - run: dotnet test ./tests/GrpcWebSocketBridge.Tests/ -c Release
       # Pack
-      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o $GITHUB_WORKSPACE/artifacts ./src/GrpcWebSocketBridge.Client
 
   build-unity:
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,8 +39,8 @@ jobs:
       # Build & Pack
       - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
       - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
-      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.Client
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,6 +27,7 @@ jobs:
     name: "Build & pack GrpcWebSocketBridge"
     permissions:
       contents: read
+      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     needs: [update-packagejson]
     timeout-minutes: 10

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -84,6 +84,8 @@ jobs:
           UNITY_SERIAL: "op://${{ vars.OP_VAULT_ACTIONS_PUBLIC }}/UNITY_LICENSE/serial"
 
       - uses: Cysharp/Actions/.github/actions/checkout@main
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: Cysharp/Actions/.github/actions/check-metas@main # check meta files
         with:
           directory: tool/GrpcWebSocketBridge.Client.Unity

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,7 +27,6 @@ jobs:
     name: "Build & pack GrpcWebSocketBridge"
     permissions:
       contents: read
-      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     needs: [update-packagejson]
     timeout-minutes: 10
@@ -46,20 +45,6 @@ jobs:
           name: nuget
           path: ./publish/
           retention-days: 1
-      # push nuget
-      - name: NuGet login (OIDC)
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        id: login
-        with:
-          user: ${{ secrets.NUGET_USER }}
-      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
-        if: ${{ !inputs.dry-run }}
-        env:
-          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
-        if: ${{ !inputs.dry-run }}
-        env:
-          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   build-unity:
     name: "Build Unity package"
@@ -91,8 +76,35 @@ jobs:
           directory: tool/GrpcWebSocketBridge.Client.Unity
 
   # release
+  publish:
+    name: "Publish NuGet packages"
+    needs: [build, build-unity]
+    permissions:
+      contents: read
+      id-token: write # required for NuGet Trusted Publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./nuget/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./nuget/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+
+  # release
   create-release:
-    needs: [update-packagejson, build, build-unity]
+    needs: [update-packagejson, publish]
     permissions:
       contents: write
       id-token: write # required for NuGet Trusted Publish

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,8 +39,8 @@ jobs:
       # Build & Pack
       - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
       - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
-      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.Client
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -43,6 +43,16 @@ jobs:
           name: nuget
           path: ./publish/
           retention-days: 1
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   build-unity:
     name: "Build Unity package"
@@ -82,7 +92,7 @@ jobs:
       commit-id: ${{ needs.update-packagejson.outputs.sha }}
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
-      nuget-push: true
+      nuget-push: false
       release-upload: false
       release-format: "{0}"
     secrets: inherit

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -33,12 +33,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       # Build & Pack
       - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
       - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
-      - run: dotnet pack -c Release --include-symbols --include-source --no-build -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --include-symbols --include-source --no-build -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --include-source --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --include-source --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.Client
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
@@ -51,6 +53,10 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
       - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
         if: ${{ !inputs.dry-run }}
         env:
           NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,8 +39,8 @@ jobs:
       # Build & Pack
       - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
       - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
-      - run: dotnet pack -c Release --include-source --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --include-source --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:VersionPrefix=${{ inputs.tag }} -o ./publish/ ./src/GrpcWebSocketBridge.Client
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,8 +39,8 @@ jobs:
       # Build & Pack
       - run: dotnet build ./src/GrpcWebSocketBridge.AspNetCore/ -c Release -p:VersionSuffix=${{ inputs.tag }}
       - run: dotnet build ./src/GrpcWebSocketBridge.Client/ -c Release -p:VersionSuffix=${{ inputs.tag }}
-      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
-      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.Client
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.AspNetCore
+      - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} --include-symbols --include-source -p:SymbolPackageFormat=snupkg -o ./publish/ ./src/GrpcWebSocketBridge.Client
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget


### PR DESCRIPTION
This updates the build-release workflow to leverage OpenID Connect (OIDC) for authenticating with NuGet.org. The package push operation is now performed directly within the build job, replacing static API key usage with ephemeral credentials for enhanced security.
